### PR TITLE
add shebang to test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import subprocess
 import sys


### PR DESCRIPTION
allows the invocation of `./test.py` when made executable on linux machines, does nothing on windows